### PR TITLE
Fix dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ python_requires = >=3.10
 # For more information, check out https://semver.org/.
 install_requires =
     frictionless[zenodo,pandas,visidata]==5.15.1
+    pandas==1.5.3  # XXX - required by ms3
     importlib-metadata~=6.0.0
     marshmallow==3.19.0
     ms3==2.0.0


### PR DESCRIPTION
Dependency fixes

- pandas must be pinned because ms3 depends on 1.5.3
- frictionless must be updated for ms3

No functional changes